### PR TITLE
修改说明文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All packages are updated and built automatically using our automation scripts, s
 ## How to use
 
 ```
-echo "deb https://dl.bintray.com/debianopt/debianopt buster main" >> /etc/apt/sources.list.d/debianopt.list
+sudo bash -c "echo "deb https://dl.bintray.com/debianopt/debianopt buster main" >> /etc/apt/sources.list.d/debianopt.list"
 curl -o bintray-public.key.asc https://bintray.com/user/downloadSubjectPublicKey?username=bintray
 sudo apt-key add bintray-public.key.asc
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All packages are updated and built automatically using our automation scripts, s
 ## How to use
 
 ```
-echo "deb https://dl.bintray.com/debianopt/debianopt buster main" | sudo tee -a /etc/apt/sources.list.d/debianopt.list
+echo "deb https://dl.bintray.com/debianopt/debianopt buster main" >> /etc/apt/sources.list.d/debianopt.list
 curl -o bintray-public.key.asc https://bintray.com/user/downloadSubjectPublicKey?username=bintray
 sudo apt-key add bintray-public.key.asc
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All packages are updated and built automatically using our automation scripts, s
 ## How to use
 
 ```
-echo "deb https://dl.bintray.com/debianopt/debianopt buster main" | sudo tee -a /etc/apt/sources.list
+echo "deb https://dl.bintray.com/debianopt/debianopt buster main" | sudo tee -a /etc/apt/sources.list.d/debianopt.list
 curl -o bintray-public.key.asc https://bintray.com/user/downloadSubjectPublicKey?username=bintray
 sudo apt-key add bintray-public.key.asc
 ```


### PR DESCRIPTION
我对说明文档中的源添加方法进行了修改，将源的地址存放从`/etc/apt/sources.list`改到`/etc/apt/sources.list.d/debianopt.list`。相对于直接写到`/etc/apt/sources.list`，这种方式源优先级更低。